### PR TITLE
Print the failing test's stacktrace to the log.

### DIFF
--- a/utiliti/src/de/gurkenlabs/utiliti/swing/LogHandler.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/swing/LogHandler.java
@@ -13,7 +13,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
 public class LogHandler extends java.util.logging.Handler {
-    private final JTextPane textPane;
+    final JTextPane textPane;
 
     public LogHandler(final JTextPane textPane) {
         this.textPane = textPane;

--- a/utiliti/tests/de/gurkenlabs/utiliti/swing/LogHandlerTest.java
+++ b/utiliti/tests/de/gurkenlabs/utiliti/swing/LogHandlerTest.java
@@ -64,6 +64,11 @@ public class LogHandlerTest {
         assertEquals(0, textPane.getCaretPosition());
 
         try {
+          System.out.println(logHandler != null);
+          if(logHandler != null) {
+            System.out.println("TextPane = " + logHandler.textPane);
+            System.out.println("doc = " + logHandler.textPane.getStyledDocument());
+          }
           logHandler.scrollToLast();
         }
         catch(Throwable t) {

--- a/utiliti/tests/de/gurkenlabs/utiliti/swing/LogHandlerTest.java
+++ b/utiliti/tests/de/gurkenlabs/utiliti/swing/LogHandlerTest.java
@@ -63,7 +63,13 @@ public class LogHandlerTest {
         assertEquals(47, styledDocument.getLength());
         assertEquals(0, textPane.getCaretPosition());
 
-        logHandler.scrollToLast();
+        try {
+          logHandler.scrollToLast();
+        }
+        catch(Throwable t) {
+          t.printStackTrace();
+          throw t;
+        }
 
         assertEquals(47, styledDocument.getLength());
         assertEquals(47, textPane.getCaretPosition());


### PR DESCRIPTION
Prints the failing test's stacktrace to the log when the test fails.

Strangely though, I'm unable to get the test to fail after these changes.